### PR TITLE
lib/mpi: Use "static inline" instead of "inline"

### DIFF
--- a/lib/mpi/mpi-inline.h
+++ b/lib/mpi/mpi-inline.h
@@ -30,7 +30,7 @@
 #define G10_MPI_INLINE_H
 
 #ifndef G10_MPI_INLINE_DECL
-#define G10_MPI_INLINE_DECL  inline
+#define G10_MPI_INLINE_DECL  static inline
 #endif
 
 G10_MPI_INLINE_DECL mpi_limb_t


### PR DESCRIPTION
The commit 2e7dc31cf2a8e3665e5c68ee03d177134b2c90ca had replaced
"extern inline" with "inline" in order to fix the build with GCC 5,
because of new inline semantics. However, this change breaks the build
with GCC 4.9, causing many errors such as:

  lib/mpi/generic_mpih-mul1.o: In function `mpihelp_add_1':
  generic_mpih-mul1.c:(.text+0x0): multiple definition of `mpihelp_add_1'
  lib/mpi/generic_mpih-lshift.o:generic_mpih-lshift.c:(.text+0x0): first defined here

Fix this like in the mainline commit
9c6bd0c2f103f4748cb4abcaf141f7d11aabfe9f, by using "static inline".

Signed-off-by: Benoît Thébaudeau <benoit@wsystem.com>