### PR TITLE
amlogic: remote: Add support for Sony SIRC 12/15/20

### DIFF
--- a/drivers/amlogic/input/remote/remote_meson.h
+++ b/drivers/amlogic/input/remote/remote_meson.h
@@ -119,6 +119,7 @@ struct remote_chip {
 	struct ir_map_tab_list *cur_tab;
 	int custom_num;
 	struct key_number key_num;
+	unsigned long repeat_max_jiffies;
 	int decode_status;
 	int sys_custom_code;
 	const char *keymap_name;

--- a/include/dt-bindings/input/meson_rc.h
+++ b/include/dt-bindings/input/meson_rc.h
@@ -22,6 +22,9 @@
 #define     REMOTE_TYPE_RC5         0x04
 #define     REMOTE_TYPE_RC6         0x05
 #define     REMOTE_TYPE_TOSHIBA     0x06
+#define     REMOTE_TYPE_SONY_SIRC12 0x07
+#define     REMOTE_TYPE_SONY_SIRC15 0x08
+#define     REMOTE_TYPE_SONY_SIRC20 0x09
 
 /*hardware decode one protocol by using legacy IR controller*/
 #define     REMOTE_TYPE_LEGACY_NEC  0xff


### PR DESCRIPTION
Contrary to most IR RC protocols, the Sony SIRC frames end with a data
bit, not with a trailer pulse, which triggers the following bugs in the
hardware IR decoder because it relies on pulse intervals instead of
pulse widths:

 - The last data bit (msb) cannot be read properly. It can only be
   dropped, in which case it is always returned as 0, or forcibly read
   by using an abnormally long maximum frame duration and ignoring the
   logic 1 timings, in which case it is stuck to 1. This implementation
   chooses to drop the msb because it is part of the device ID, so this
   limitation is very unlikely to cause any trouble.

 - The repeat maximum frame interval in AO_MF_IR_DEC_REG3 is ignored.
   Consequently, if the same RC key is pressed twice in a row, the
   decoder reports the second key press as a repeat event, even if there
   is a very long time between the key presses. This implementation
   works around this bug by considering reported repeat events as actual
   normal events if they occur more than a given time after the previous
   event.

In order to support the SIRC protocol without any limitation, a software
decoder would have to be used with the general time measurement mode. To
this end, an equivalent of
drivers/amlogic/input/remote/remote_decoder_xmp.c for SIRC could be
derived from drivers/media/rc/ir-sony-decoder.c.