### PR TITLE
Add support for Amlogic GPIO IRQs to various drivers

### DIFF
--- a/Documentation/devicetree/bindings/input/rotary-encoder.txt
+++ b/Documentation/devicetree/bindings/input/rotary-encoder.txt
@@ -3,6 +3,9 @@ Rotary encoder DT bindings
 Required properties:
 - gpios: a spec for two GPIOs to be used
 
+Properties required if Amlogic GPIOs are used:
+- interrupts: a list of 4 specifiers for the interrupts to be used
+
 Optional properties:
 - linux,axis: the input subsystem axis to map to this rotary encoder.
   Defaults to 0 (ABS_X / REL_X)

--- a/drivers/i2c/i2c-core.c
+++ b/drivers/i2c/i2c-core.c
@@ -253,8 +253,10 @@ static int i2c_device_probe(struct device *dev)
 	if (!client->irq && dev->of_node) {
 		int irq = of_irq_get(dev->of_node, 0);
 
-		if (irq < 0)
+		if (irq == -EPROBE_DEFER)
 			return irq;
+		if (irq < 0)
+			irq = 0;
 
 		client->irq = irq;
 	}

--- a/drivers/i2c/i2c-core.c
+++ b/drivers/i2c/i2c-core.c
@@ -250,6 +250,15 @@ static int i2c_device_probe(struct device *dev)
 	if (!client)
 		return 0;
 
+	if (!client->irq && dev->of_node) {
+		int irq = of_irq_get(dev->of_node, 0);
+
+		if (irq < 0)
+			return irq;
+
+		client->irq = irq;
+	}
+
 	driver = to_i2c_driver(dev->driver);
 	if (!driver->probe || !driver->id_table)
 		return -ENODEV;
@@ -1021,7 +1030,6 @@ static void of_i2c_register_devices(struct i2c_adapter *adap)
 			continue;
 		}
 
-		info.irq = irq_of_parse_and_map(node, 0);
 		info.of_node = of_node_get(node);
 		info.archdata = &dev_ad;
 
@@ -1035,7 +1043,6 @@ static void of_i2c_register_devices(struct i2c_adapter *adap)
 			dev_err(&adap->dev, "of_i2c: Failure registering %s\n",
 				node->full_name);
 			of_node_put(node);
-			irq_dispose_mapping(info.irq);
 			continue;
 		}
 	}

--- a/include/linux/rotary_encoder.h
+++ b/include/linux/rotary_encoder.h
@@ -8,6 +8,7 @@ struct rotary_encoder_platform_data {
 	unsigned int gpio_b;
 	unsigned int inverted_a;
 	unsigned int inverted_b;
+	unsigned int irqs[4];
 	bool relative_axis;
 	bool rollover;
 	bool half_period;


### PR DESCRIPTION
Amlogic's GPIO driver handles interrupts in a non-standard way. Therefore, all the drivers needing Amlogic GPIO IRQs have to be modified in order to support them. This pull request does this for the pca953x and rotary-encoder drivers.

This PR also adds two upstream fixes for I²C, making it possible to use cascaded GPIO expanders by fixing:
```
[    0.501419@0] irq: no irq domain found for /i2c@c11087c0/gpio-expander@20 !
```

This PR is useful for VIM expansion boards.