### PR TITLE
eeprom: at24: Simplify WP management and make it optional

### DIFF
--- a/arch/arm64/boot/dts/amlogic/gxtvbb_p301.dts
+++ b/arch/arm64/boot/dts/amlogic/gxtvbb_p301.dts
@@ -1760,7 +1760,6 @@
 			pagesize = <8>;
 			write_ops_interval= <10>;/*Write operation interval  at24c32 at24c64 is 10ms  at24c128 is 5ms in spec*/
 			wp_gpios = <&gpio  GPIOY_7  GPIO_ACTIVE_HIGH>;
-			write_gpio_port_status = <0>;
 		};
 	};
 &pinmux {

--- a/include/linux/platform_data/at24.h
+++ b/include/linux/platform_data/at24.h
@@ -47,17 +47,11 @@ struct at24_platform_data {
 #define AT24_FLAG_READONLY	0x40	/* sysfs-entry will be read-only */
 #define AT24_FLAG_IRUGO		0x20	/* sysfs-entry will be world-readable */
 #define AT24_FLAG_TAKE8ADDR	0x10	/* take always 8 addresses (24c00) */
-	unsigned int wp_port;
-	unsigned int wp_port_level;
-	unsigned int wp_port_level_save;
+	int wp_port;
+	unsigned int wp_port_active_level;
 	unsigned int write_ops_interval;
-	struct gpio_desc *wp_pin_desc;
 	void		(*setup)(struct memory_accessor *, void *context);
 	void		*context;
 };
-extern int amlogic_gpio_name_map_num(const char *name);
-extern int amlogic_gpio_direction_output(unsigned int pin, int value,
-					 const char *owner);
-extern int amlogic_gpio_request(unsigned int pin, const char *label);
 
 #endif /* _LINUX_AT24_H */


### PR DESCRIPTION
The WP management introduced by Amlogic was uselessly complicated. It was also silently mandatory, which caused the following error without a WP-control GPIO:

```
[    1.972520@0] faild to get write interval time !
[    1.977044@0] faild to get write interval time !
[    1.981698@0] ------------[ cut here ]------------
[    1.986505@0] WARNING: CPU: 0 PID: 1 at /home/terry/project/vim/nougat/common/drivers/gpio/gpiolib.c:159 gpio_to_desc+0x58/0x60()
[    1.998257@0] invalid GPIO -1514520
[    2.001731@0] Modules linked in:
[    2.004961@0] CPU: 0 PID: 1 Comm: swapper/0 Not tainted 3.14.29-g576a041-dirty #14
[    2.012575@0] Call trace:
[    2.015201@0] [<ffffffc001088fe8>] dump_backtrace+0x0/0x140
[    2.020830@0] [<ffffffc001089148>] show_stack+0x20/0x2c
[    2.026046@0] [<ffffffc001b17acc>] dump_stack+0x74/0xc0
[    2.031302@0] [<ffffffc00109eaa0>] warn_slowpath_common+0x90/0xb8
[    2.037438@0] [<ffffffc00109eb3c>] warn_slowpath_fmt+0x74/0x88
[    2.043290@0] [<ffffffc00143b73c>] gpio_to_desc+0x54/0x60
[    2.048706@0] [<ffffffc00143c430>] gpio_request+0x20/0x38
[    2.054157@0] [<ffffffc0014a5130>] at24_wp_enable+0x30/0x78
[    2.059731@0] [<ffffffc0014a558c>] at24_dt_parse+0x9c/0x110
[    2.065338@0] [<ffffffc0014a5914>] at24_probe+0x314/0x584
[    2.070782@0] [<ffffffc00159d560>] i2c_device_probe+0xa0/0xe4
[    2.076533@0] [<ffffffc001485d08>] really_probe+0x74/0x240
[    2.082051@0] [<ffffffc00148600c>] __driver_attach+0xb0/0xb8
[    2.087749@0] [<ffffffc001483e54>] bus_for_each_dev+0x68/0xac
[    2.093513@0] [<ffffffc001485810>] driver_attach+0x2c/0x38
[    2.099019@0] [<ffffffc001485414>] bus_add_driver+0x158/0x210
[    2.104818@0] [<ffffffc0014867b0>] driver_register+0x6c/0x138
[    2.110575@0] [<ffffffc00159d3dc>] i2c_register_driver+0x3c/0xc0
[    2.116609@0] [<ffffffc001f66480>] at24_init+0x50/0x5c
[    2.121792@0] [<ffffffc0010816b8>] do_one_initcall+0xe0/0x12c
[    2.127546@0] [<ffffffc001f38924>] kernel_init_freeable+0x134/0x1d8
[    2.133851@0] [<ffffffc001b0f390>] kernel_init+0x1c/0xdc
[    2.139213@0] ---[ end trace c84d7b19dc3d49e2 ]---
[    2.144000@0] gpiod_request: invalid GPIO
[    2.148017@0] faild to alloc write protect (-1514520)!
[    2.153185@0] EEPROM_AT24c256
[    2.156086@0] write protect port level is -1514520[    2.160888@0] wp_port=-1514520 write_ops_interval=-64ms
[    2.166151@0] at24 2-0050: 32768 byte 24c256 EEPROM, writable, 64 bytes/write
```