### PR TITLE
mm/readahead: Fix null pointer

### DIFF
--- a/mm/readahead.c
+++ b/mm/readahead.c
@@ -161,7 +161,7 @@ int __do_page_cache_readahead(struct address_space *mapping, struct file *filp,
 	gfp_t gfp_mask = readahead_gfp_mask(mapping);
 
 #ifdef CONFIG_AMLOGIC_CMA
-	if (filp->f_mode & (FMODE_WRITE | FMODE_WRITE_IOCTL))
+	if (filp && (filp->f_mode & (FMODE_WRITE | FMODE_WRITE_IOCTL)))
 		gfp_mask |= __GFP_WRITE;
 #endif /* CONFIG_AMLOGIC_CMA */
 


### PR DESCRIPTION
When using BTRFS, the kernel panics on boot during mount with the following
error message: `Unable to handle kernel NULL pointer dereference at virtual
address 00000044`

The responsible code snippet has been added to mm/readahead and contains a
null pointer: `filp` can be NULL when using filesystems writing metadata
(e.g. btrfs)

Fix this issue by extending the if-clause