### PR TITLE
VIM3: dwmac-meson: Solve Wol not effective

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-meson.c
+++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-meson.c
@@ -660,7 +660,7 @@ static int meson6_dwmac_probe(struct platform_device *pdev)
 	ret = stmmac_dvr_probe(&pdev->dev, plat_dat, &stmmac_res);
 	if (ret)
 		goto err_remove_config_dt;
-	if (support_mac_wol)
+ //	if (support_mac_wol)
 		device_init_wakeup(&pdev->dev, 1);
 	return 0;
 


### PR DESCRIPTION
VIM3: dwmac-meson: Solve Wol not effective
Signed-off-by: Jack Zhao <jack.zhao@wesion.com>