### PR TITLE
arm64: dts: IR: Edge2: Changes the representation of the remote key v…

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
@@ -776,19 +776,19 @@
 	ir_key1 {
 		rockchip,usercode = <0xff00>;
 		rockchip,key_table =
-			<0xeb 116>,		//KEY_POWER
-			<0xec 139>,		//KEY_MENU
-			<0xfc 103>,		//KEY_UP
-			<0xfd 108>,		//KEY_DOWN
-			<0xf1 105>,		//KEY_LEFT
-			<0xe5 106>,		//KEY_RIGHT
-			<0xf8 28>, 		//KEY_Enter
-			<0xa7 114>,		//KEY_VOLUMEDOWN
-			<0xa3 388>,
-			<0xa4 388>,		//KEY_CURSOR
-			<0xf4 115>,		//KEY_VOLUMEUP
-			<0xfe 158>,		//KEY_BACK
-			<0xb7 172>;		//KEY_HOMEPAGE
+			<0xeb KEY_POWER>,
+			<0xec KEY_MENU>,
+			<0xfc KEY_UP>,
+			<0xfd KEY_DOWN>,
+			<0xf1 KEY_LEFT>,
+			<0xe5 KEY_RIGHT>,
+			<0xf8 KEY_ENTER>,
+			<0xa7 KEY_VOLUMEDOWN>,
+			<0xa3 KEY_CURSOR>,
+			<0xa4 KEY_CURSOR>,
+			<0xf4 KEY_VOLUMEUP>,
+			<0xfe KEY_BACK>,
+			<0xb7 KEY_HOMEPAGE>;
 	};
 };
 

--- a/include/dt-bindings/input/rk-input.h
+++ b/include/dt-bindings/input/rk-input.h
@@ -314,6 +314,8 @@
 
 #define KEY_MICMUTE		248	/* Mute / unmute the microphone */
 
+#define KEY_CURSOR      388
+
 /* Code 255 is reserved for special needs of AT keyboard driver */
 
 #define BTN_MISC		0x100


### PR DESCRIPTION
…alue

Change the numeric representation of the remote key value to the macro definition.

Signed-off-by: Ivan.li <ivan.li@wesion.com>
Change-Id: I38ef3b0b6120926a52c0b434fbefca2e4be1ab4a