### PR TITLE
arm64: dts: VIM3L: Fix DT overlays to enable spi

### DIFF
--- a/arch/arm64/boot/dts/amlogic/kvim3l_linux.dts
+++ b/arch/arm64/boot/dts/amlogic/kvim3l_linux.dts
@@ -1672,8 +1672,6 @@
 
 &pwm_ef {
 	status = "okay";
-	pinctrl-names = "default";
-	pinctrl-0 = <&pwm_f_pins2>;
 };
 
 &dwc3 {


### PR DESCRIPTION
Signed-off-by: Ivan.li <ivan.li@wesion.com>
Change-Id: I9e0d90456c1940e67cdead1af1623fd350c1a887