### PR TITLE
Makefile: fix build errors with gcc 12.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -527,7 +527,7 @@ KBUILD_AFLAGS   := -D__ASSEMBLY__ -fno-PIE
 KBUILD_CFLAGS   := -Wall -Wundef -Werror=strict-prototypes -Wno-trigraphs \
 		   -fno-strict-aliasing -fno-common -fshort-wchar -fno-PIE \
 		   -Werror=implicit-function-declaration -Werror=implicit-int \
-		   -Werror=return-type -Wno-format-security \
+		   -Werror=return-type -Wno-format-security -Wno-address \
 		   -std=gnu89
 KBUILD_CPPFLAGS := -D__KERNEL__
 KBUILD_AFLAGS_KERNEL :=


### PR DESCRIPTION
Change-Id: Ic7db7ce5d7650042924a46e6ca22bd4ca58e5ad6