### PR TITLE
drm/bridge: synopsys: dw-hdmi-qp: Set RGB888 as default color fmt.

### DIFF
--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
+++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
@@ -2904,7 +2904,7 @@ dw_hdmi_connector_set_property(struct drm_connector *connector,
 static void dw_hdmi_attach_properties(struct dw_hdmi_qp *hdmi)
 {
 	u32 val;
-	u64 color = MEDIA_BUS_FMT_YUV8_1X24;
+	u64 color = MEDIA_BUS_FMT_RGB888_1X24;
 	const struct dw_hdmi_property_ops *ops =
 				hdmi->plat_data->property_ops;
 	void *data = hdmi->plat_data->phy_data;


### PR DESCRIPTION
Change-Id: I382148754bb69f5fd16df220cea69df56eff7a39